### PR TITLE
Add CLI for running tracktour on CTC data

### DIFF
--- a/examples/build_and_solve_ctc.ipynb
+++ b/examples/build_and_solve_ctc.ipynb
@@ -152,21 +152,11 @@
    "outputs": [],
    "source": [
     "# convert solution to networkx graph\n",
-    "import networkx as nx\n",
+    "sol_graph = tracked.as_nx_digraph()\n",
     "\n",
-    "tracked_edges = tracked.tracked_edges\n",
-    "tracked_detections = tracked.tracked_detections\n",
-    "\n",
-    "sol_graph = nx.from_pandas_edgelist(\n",
-    "    tracked_edges, \n",
-    "    \"u\", \n",
-    "    \"v\", \n",
-    "    [\"flow\"], # optional but may be useful for debugging or finding merge edges\n",
-    "    create_using=nx.DiGraph\n",
-    ")\n",
-    "sol_graph.add_nodes_from(\n",
-    "    tracked_detections[[\"t\", \"y\", \"x\", \"label\"]].to_dict(orient='index').items()\n",
-    ")"
+    "# convert to CTC output\n",
+    "from tracktour import get_ctc_output\n",
+    "seg, tdf = get_ctc_output(seg_labels, sol_graph, frame_key='t', value_key='label')\n"
    ]
   },
   {

--- a/examples/build_and_solve_ctc.ipynb
+++ b/examples/build_and_solve_ctc.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -25,39 +25,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Loading TIFFs: 100%|██████████| 92/92 [00:00<00:00, 277.03it/s]\n",
-      "Extracting Centroids: 100%|██████████| 92/92 [00:02<00:00, 31.01it/s]"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Loaded 92 frames of shape (700, 1100).\n",
-      "Extracted 25378 detections:\n",
-      "   t           y           x  label\n",
-      "0  0  105.033501   17.544389      1\n",
-      "1  0  106.990672  117.902985     20\n",
-      "2  0   73.033403  143.325678     24\n",
-      "3  0  108.000000  171.669355     28\n",
-      "4  0  141.251956  138.192488     32\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "seg_labels, detections, min_t, max_t, corners = get_im_centers(SEG_PATH)\n",
     "print(f\"Loaded {seg_labels.shape[0]} frames of shape {seg_labels.shape[1:]}.\")\n",
@@ -67,69 +37,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Computing candidate edges: 100%|██████████| 91/91 [00:00<00:00, 1279.92it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Set parameter Username\n",
-      "Academic license - for non-commercial use only - expires 2024-10-24\n",
-      "Gurobi Optimizer version 10.0.0 build v10.0.0rc2 (linux64)\n",
-      "\n",
-      "CPU model: 11th Gen Intel(R) Core(TM) i7-11850H @ 2.50GHz, instruction set [SSE2|AVX|AVX2|AVX512]\n",
-      "Thread count: 8 physical cores, 16 logical processors, using up to 16 threads\n",
-      "\n",
-      "Optimize a model with 75774 rows, 325923 columns and 1248939 nonzeros\n",
-      "Model fingerprint: 0xf07cfc27\n",
-      "Coefficient statistics:\n",
-      "  Matrix range     [1e+00, 1e+00]\n",
-      "  Objective range  [3e-03, 3e+02]\n",
-      "  Bounds range     [1e+00, 2e+00]\n",
-      "  RHS range        [1e+00, 1e+00]\n",
-      "Presolve removed 3 rows and 2 columns\n",
-      "Presolve time: 0.43s\n",
-      "Presolved: 75771 rows, 325921 columns, 1248909 nonzeros\n",
-      "\n",
-      "Concurrent LP optimizer: primal simplex, dual simplex, and barrier\n",
-      "Showing barrier log only...\n",
-      "\n",
-      "Ordering time: 0.38s\n",
-      "\n",
-      "Barrier performed 0 iterations in 0.91 seconds (0.91 work units)\n",
-      "Barrier solve interrupted - model solved by another algorithm\n",
-      "\n",
-      "\n",
-      "Solved with dual simplex\n",
-      "Iteration    Objective       Primal Inf.    Dual Inf.      Time\n",
-      "   28337    8.4615302e+04   0.000000e+00   0.000000e+00      1s\n",
-      "\n",
-      "Solved in 28337 iterations and 0.97 seconds (1.12 work units)\n",
-      "Optimal objective  8.461530227e+04\n",
-      "Building took 14.285187005996704 seconds\n",
-      "   t           y           x  label  enter_exit_cost   div_cost\n",
-      "0  0  105.033501   17.544389      1        17.544389  54.374273\n",
-      "1  0  106.990672  117.902985     20       106.990672  47.543552\n",
-      "2  0   73.033403  143.325678     24        73.033403  49.021949\n",
-      "3  0  108.000000  171.669355     28       108.000000  50.412891\n",
-      "4  0  141.251956  138.192488     32       138.192488  68.057136\n",
-      "    index  u    v   distance  capacity       cost  flow\n",
-      "0       0  0  124  21.894248       2.0  21.894248   1.0\n",
-      "10     10  1  126   4.574182       2.0   4.574182   1.0\n",
-      "20     20  2  127   6.052579       2.0   6.052579   1.0\n",
-      "30     30  3  128   6.687392       2.0   6.687392   1.0\n",
-      "40     40  4  129  15.395290       2.0  15.395290   1.0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "tracker = Tracker(\n",
     "    im_shape = corners[1],\n",
@@ -147,35 +57,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "# convert solution to networkx graph\n",
-    "sol_graph = tracked.as_nx_digraph()\n",
-    "\n",
-    "# convert to CTC output\n",
-    "from tracktour import get_ctc_output\n",
-    "seg, tdf = get_ctc_output(seg_labels, sol_graph, frame_key='t', value_key='label')\n"
+    "sol_graph = tracked.as_nx_digraph()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "ModuleNotFoundError",
-     "evalue": "No module named 'traccuracy'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mModuleNotFoundError\u001b[0m                       Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[6], line 3\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;66;03m# evaluate using `traccuracy` - note `traccuracy` should be installed separately!\u001b[39;00m\n\u001b[0;32m----> 3\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mtraccuracy\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m TrackingGraph\n\u001b[1;32m      4\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mtraccuracy\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mloaders\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m load_ctc_data\n\u001b[1;32m      5\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mtraccuracy\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mmatchers\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m CTCMatcher\n",
-      "\u001b[0;31mModuleNotFoundError\u001b[0m: No module named 'traccuracy'"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# evaluate using `traccuracy` - note `traccuracy` should be installed separately!\n",
     "\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "scikit-image",
     "scipy",
     "tifffile", # maybe should be optional?
+    "typer",
     "tqdm",
 ]
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,3 +66,6 @@ repository = "https://github.com/DragaDoncila/tracktour"
 
 [project.entry-points."napari.manifest"]
 napari-tracktour = "tracktour:napari.yaml"
+
+[project.scripts]
+tracktour = "tracktour.cli:main"

--- a/src/tracktour/__init__.py
+++ b/src/tracktour/__init__.py
@@ -8,11 +8,12 @@ except PackageNotFoundError:
 __author__ = "Draga Doncila Pop"
 __email__ = "ddoncila@gmail.com"
 
-from ._io_util import get_im_centers, load_tiff_frames
+from ._io_util import get_ctc_output, get_im_centers, load_tiff_frames
 from ._tracker import Tracker
 
 __all__ = [
     "Tracker",
+    "get_ctc_output",
     "get_im_centers",
     "load_tiff_frames",
 ]

--- a/src/tracktour/_costs.py
+++ b/src/tracktour/_costs.py
@@ -57,6 +57,12 @@ def closest_neighbour_child_cost(detections, location_keys, edge_df):
                 for v in edge_group["v"].values
             ]
         )
+        # if there's only one child, node cannot divide so cost is infinite
+        # TODO: just don't have these edges at all
+        if len(child_coord_array) == 1:
+            min_dists[det_row.Index] = math.inf
+            continue
+
         dists_to_child = np.linalg.norm(src_coords - child_coord_array, axis=1)
         inter_child_dists = pdist(child_coord_array)
         div_costs = inter_child_dists + np.asarray(

--- a/src/tracktour/_graph_util.py
+++ b/src/tracktour/_graph_util.py
@@ -1,4 +1,5 @@
 import networkx as nx
+import pandas as pd
 
 
 def assign_track_id(nx_sol):
@@ -54,3 +55,24 @@ def assign_intertrack_edges(nx_g: "nx.DiGraph"):
         # destination has two parents
         if len(nx_g.in_edges(dest)) > 1:
             nx_g.edges[e]["is_intertrack_edge"] = 1
+
+
+def get_ctc_tracks(tracked_sol):
+    """Given nx solution graph, return CTC formatted track df.
+
+    Each row in the df defines a track using ID, start frame, end frame, parent
+
+    Parameters
+    ----------
+    tracked_sol : nx.DiGraph
+        networkx solution graph with track-id assigned
+    """
+    node_df = pd.DataFrame.from_dict(tracked_sol.nodes, orient="index")
+    # group solution by track id
+    print(node_df)
+
+    # get min_t and max_t for each group
+
+    # for each end node (at max_t), follow edge to its parents
+
+    # TODO!!!!: ARBITRARILY PICK THE CLOSEST PARENT???

--- a/src/tracktour/_io_util.py
+++ b/src/tracktour/_io_util.py
@@ -7,6 +7,9 @@ from skimage.measure import regionprops
 from skimage.morphology import skeletonize
 from tifffile import imread
 
+from tracktour._graph_util import assign_track_id, get_ctc_tracks
+from tracktour._viz_util import mask_by_id
+
 try:
     from napari.utils import progress as tqdm
 except ImportError:
@@ -25,6 +28,14 @@ def load_tiff_frames(im_dir):
 
     im = np.stack(stack)
     return im
+
+
+def get_ctc_output(original_seg, tracked_nx, frame_key, value_key):
+    max_id = assign_track_id(tracked_nx)
+    node_df = pd.DataFrame.from_dict(tracked_nx.nodes, orient="index")
+    relabelled_seg = mask_by_id(node_df, original_seg, frame_key, value_key)
+    track_df = get_ctc_tracks(tracked_nx)
+    return relabelled_seg, track_df
 
 
 def get_im_centers(im_pth):

--- a/src/tracktour/_io_util.py
+++ b/src/tracktour/_io_util.py
@@ -7,7 +7,7 @@ from skimage.measure import regionprops
 from skimage.morphology import skeletonize
 from tifffile import imread
 
-from tracktour._graph_util import assign_track_id, get_ctc_tracks
+from tracktour._graph_util import assign_track_id, get_ctc_tracks, remove_merges
 from tracktour._viz_util import mask_by_id
 
 try:
@@ -30,11 +30,13 @@ def load_tiff_frames(im_dir):
     return im
 
 
-def get_ctc_output(original_seg, tracked_nx, frame_key, value_key):
-    max_id = assign_track_id(tracked_nx)
-    node_df = pd.DataFrame.from_dict(tracked_nx.nodes, orient="index")
+def get_ctc_output(original_seg, tracked_nx, frame_key, value_key, location_keys):
+    # remove merges from tracked_nx - keep closest node
+    mergeless = remove_merges(tracked_nx, location_keys)
+    max_id = assign_track_id(mergeless)
+    node_df = pd.DataFrame.from_dict(mergeless.nodes, orient="index")
     relabelled_seg = mask_by_id(node_df, original_seg, frame_key, value_key)
-    track_df = get_ctc_tracks(tracked_nx)
+    track_df = get_ctc_tracks(mergeless)
     return relabelled_seg, track_df
 
 

--- a/src/tracktour/_io_util.py
+++ b/src/tracktour/_io_util.py
@@ -1,4 +1,5 @@
 import glob
+import os
 
 import numpy as np
 import pandas as pd
@@ -17,7 +18,7 @@ except ImportError:
 
 
 def load_tiff_frames(im_dir):
-    all_tiffs = list(sorted(glob.glob(f"{im_dir}*.tif")))
+    all_tiffs = list(sorted(glob.glob(os.path.join(im_dir, "*.tif"))))
     n_frames = len(all_tiffs)
     if not n_frames:
         raise FileNotFoundError(f"Couldn't find any .tif files in {im_dir}")

--- a/src/tracktour/_viz_util.py
+++ b/src/tracktour/_viz_util.py
@@ -1,8 +1,9 @@
 import networkx as nx
 import numpy as np
+import pandas as pd
 
 
-def mask_by_id(nodes, seg, frame_key, value_key):
+def mask_by_id(nodes: pd.DataFrame, seg: np.ndarray, frame_key: str, value_key: str):
     masks = np.zeros_like(seg)
     max_id = nodes["track-id"].max()
     for i in range(1, max_id + 1):

--- a/src/tracktour/cli.py
+++ b/src/tracktour/cli.py
@@ -7,11 +7,14 @@ from tracktour import Tracker, get_ctc_output, get_im_centers
 
 
 def _save_results(masks, tracks, out_dir):
+    os.makedirs(out_dir, exist_ok=True)
     for i, frame in enumerate(masks):
         frame_out_name = os.path.join(out_dir, f"mask{str(i).zfill(3)}.tif")
         imwrite(frame_out_name, frame)
 
-    tracks.to_csv(os.path.join(out_dir, "res_track.txt"), sep=" ", index=False)
+    tracks.to_csv(
+        os.path.join(out_dir, "res_track.txt"), sep=" ", index=False, header=False
+    )
 
 
 def _run_tracktour(seg_directory, out_directory, k_neighbours=10):

--- a/src/tracktour/cli.py
+++ b/src/tracktour/cli.py
@@ -1,9 +1,44 @@
 import argparse
+import os
+
+from tifffile import imwrite
 
 from tracktour import Tracker, get_ctc_output, get_im_centers
 
+
+def _save_results(masks, tracks, out_dir):
+    for i, frame in enumerate(masks):
+        frame_out_name = os.path.join(out_dir, f"mask{str(i).zfill(3)}.tif")
+        imwrite(frame_out_name, frame)
+
+    tracks.to_csv(os.path.join(out_dir, "res_track.txt"), sep=" ", index=False)
+
+
+def _run_tracktour(seg_directory, out_directory, k_neighbours=10):
+    ims, detections, _, _, _ = get_im_centers(seg_directory)
+    frame_shape = ims.shape[1:]
+    location_keys = ("y", "x")
+    if len(frame_shape) == 3:
+        location_keys = ("z",) + ("y", "x")
+    frame_key = "t"
+    value_key = "label"
+
+    tracker = Tracker(frame_shape, k_neighbours)
+    tracked = tracker.solve(
+        detections,
+        frame_key=frame_key,
+        location_keys=location_keys,
+        value_key=value_key,
+    )
+    sol_graph = tracked.as_nx_digraph()
+    relabelled_seg, track_df = get_ctc_output(
+        ims, sol_graph, frame_key, value_key, location_keys
+    )
+    _save_results(relabelled_seg, track_df, out_directory)
+
+
 parser = argparse.ArgumentParser(
-    description="Run tracktour on a segmentation and save results."
+    description="Run tracktour on a segmentation and save results in CTC format."
 )
 parser.add_argument(
     "seg_directory",
@@ -24,35 +59,11 @@ parser.add_argument(
     help="Number of neighbours to consider for assignment in next frame, by default 10.",
 )
 
-# generate res_track file
-
-# save masked segmentation
-
-# save res_track file
-
 
 def main():
     args = parser.parse_args()
-    ims, detections, _, _, _ = get_im_centers(args.seg_directory)
-    frame_shape = ims.shape[1:]
-    location_keys = ("y", "x")
-    if len(frame_shape) == 3:
-        location_keys = ("z",) + ("y", "x")
-
-    tracker = Tracker(frame_shape, args.k_neighbours)
-    tracked = tracker.solve(
-        detections, frame_key="t", location_keys=location_keys, value_key="label"
-    )
-    sol_graph = tracked.as_nx_digraph()
-
-    print(sol_graph.number_of_nodes())
-
-    print(args.out_directory)
+    _run_tracktour(args.seg_directory, args.out_directory, args.k_neighbours)
 
 
 if __name__ == "__main__":
     main()
-    # main(
-    #     '~/PhD/data/cell_tracking_challenge/ST/Fluo-N2DL-HeLa/02_ST/SEG/',
-    #     '~/PhD/data/cell_tracking_challenge/ST/Fluo-N2DL-HeLa/02_RES/'
-    # )

--- a/src/tracktour/cli.py
+++ b/src/tracktour/cli.py
@@ -8,8 +8,9 @@ from tracktour import Tracker, get_ctc_output, get_im_centers
 
 def _save_results(masks, tracks, out_dir):
     os.makedirs(out_dir, exist_ok=True)
+    n_digits = len(str(len(masks)))
     for i, frame in enumerate(masks):
-        frame_out_name = os.path.join(out_dir, f"mask{str(i).zfill(3)}.tif")
+        frame_out_name = os.path.join(out_dir, f"mask{str(i).zfill(n_digits)}.tif")
         imwrite(frame_out_name, frame)
 
     tracks.to_csv(

--- a/src/tracktour/cli.py
+++ b/src/tracktour/cli.py
@@ -1,0 +1,58 @@
+import argparse
+
+from tracktour import Tracker, get_ctc_output, get_im_centers
+
+parser = argparse.ArgumentParser(
+    description="Run tracktour on a segmentation and save results."
+)
+parser.add_argument(
+    "seg_directory",
+    type=str,
+    help="Input directory containing tiff segmentation for each frame.",
+)
+parser.add_argument(
+    "out_directory",
+    type=str,
+    help="Output directory to save tracked segmentation and track info.",
+)
+parser.add_argument(
+    "-k",
+    "--k-neighbours",
+    dest="k_neighbours",
+    default=10,
+    type=int,
+    help="Number of neighbours to consider for assignment in next frame, by default 10.",
+)
+
+# generate res_track file
+
+# save masked segmentation
+
+# save res_track file
+
+
+def main():
+    args = parser.parse_args()
+    ims, detections, _, _, _ = get_im_centers(args.seg_directory)
+    frame_shape = ims.shape[1:]
+    location_keys = ("y", "x")
+    if len(frame_shape) == 3:
+        location_keys = ("z",) + ("y", "x")
+
+    tracker = Tracker(frame_shape, args.k_neighbours)
+    tracked = tracker.solve(
+        detections, frame_key="t", location_keys=location_keys, value_key="label"
+    )
+    sol_graph = tracked.as_nx_digraph()
+
+    print(sol_graph.number_of_nodes())
+
+    print(args.out_directory)
+
+
+if __name__ == "__main__":
+    main()
+    # main(
+    #     '~/PhD/data/cell_tracking_challenge/ST/Fluo-N2DL-HeLa/02_ST/SEG/',
+    #     '~/PhD/data/cell_tracking_challenge/ST/Fluo-N2DL-HeLa/02_RES/'
+    # )


### PR DESCRIPTION
After this PR `tracktour` can be used from the command line to solve Cell Tracking Challenge datasets and save output in Cell Tracking Challenge format. 

To run `tracktour` on a Cell Tracking Challenge dataset, use e.g.

```sh
tracktour ctc path/to/Fluo-N2DL-HeLa/01_ST/SEG/ path/to/output/Fluo-N2DL-HeLa/01_RES -k 3
```

Additionally, two small bugs in the tracker are fixed:

- error in division costs for single possible child
- bug with searching for tifs in directories when passed path didn't end with `/`