### PR TITLE
Add `scale` for images and detections

### DIFF
--- a/examples/toy.py
+++ b/examples/toy.py
@@ -18,6 +18,7 @@ coords = pd.DataFrame(coords, columns=["t", "y", "x"])
 
 tracker = Tracker(im_shape=(100, 100), k_neighbours=2)
 Tracker.DEBUG_MODE = True
-tracked = tracker.solve(coords)
+# y coordinate is a tenth the magnitude of x coordinate
+tracked = tracker.solve(coords, scale=(0.1, 1))
 print(tracked.tracked_detections)
 print(tracked.tracked_edges)

--- a/src/tracktour/_tracker.py
+++ b/src/tracktour/_tracker.py
@@ -170,11 +170,16 @@ class Tracker:
         self.frame_key = frame_key
         self.value_key = value_key
 
+        # scale detections (keeping original columns)
         self._scaled_location_keys = [f"{key}_scaled" for key in location_keys]
         for i in range(len(self.location_keys)):
             detections[self._scaled_location_keys[i]] = (
                 detections[self.location_keys[i]] * self.scale[i]
             )
+        # scale frame shape
+        self.im_shape = tuple(
+            self.im_shape[i] * scale[i] for i in range(len(self.im_shape))
+        )
 
         # TODO: copy/validate detections
         start = time.time()

--- a/src/tracktour/_tracker.py
+++ b/src/tracktour/_tracker.py
@@ -136,6 +136,7 @@ class Tracker:
     def solve(
         self,
         detections: pd.DataFrame,
+        scale: Tuple[float] = (1, 1),
         frame_key: str = "t",
         location_keys: Tuple[str] = ("y", "x"),
         # TODO: we should be able to make this optional
@@ -150,28 +151,37 @@ class Tracker:
         detections : pd.DataFrame
             dataframe where each row is a detection, with coordinates at location_keys and time at frame_key. Index must be sequential integers from 0. Detections
             must be sorted by frame.
+        scale: Tuple[float]
+            pixel scale in each dimension e.g. (0.4, 0.4) or (1, 0.3, 0.3)
         frame_key : str, optional
-            _description_, by default "t"
+            dataframe column denoting the image frame, by default "t"
         location_keys : Tuple[str], optional
-            _description_, by default ("y", "x")
+            dataframe columns denoting the pixel coordinates, by default ("y", "x")
         value_key : Optional[str], optional
-            _description_, by default None
+            dataframe column denoting the value of the pixel at the given coordinates, by default None
 
         Returns
         -------
         _type_
             _description_d
         """
+        self.scale = scale
         self.location_keys = location_keys
         self.frame_key = frame_key
         self.value_key = value_key
+
+        self._scaled_location_keys = [f"{key}_scaled" for key in location_keys]
+        for i in range(len(self.location_keys)):
+            detections[self._scaled_location_keys[i]] = (
+                detections[self.location_keys[i]] * self.scale[i]
+            )
 
         # TODO: copy/validate detections
         start = time.time()
 
         # build kd-trees
         # TODO: stop passing stuff around now that you store it as an attribute
-        kd_dict = self._build_trees(detections, frame_key, location_keys)
+        kd_dict = self._build_trees(detections, frame_key, self._scaled_location_keys)
 
         # get candidate edges
         edge_df = self._get_candidate_edges(detections, frame_key, kd_dict)
@@ -181,14 +191,14 @@ class Tracker:
 
         # compute costs for division and appearance/exit - on vertices
         enter_exit_cost, div_cost = self._compute_detection_costs(
-            detections, location_keys, edge_df
+            detections, self._scaled_location_keys, edge_df
         )
         detections["enter_exit_cost"] = enter_exit_cost
         detections["div_cost"] = div_cost
 
         # build model
         model, all_edges, all_vertices, gb_time = self._to_gurobi_model(
-            detections, edge_df, frame_key, location_keys
+            detections, edge_df, frame_key, self._scaled_location_keys
         )
 
         build_duration = time.time() - start

--- a/src/tracktour/_tracker.py
+++ b/src/tracktour/_tracker.py
@@ -487,6 +487,8 @@ class Tracker:
         return full_det
 
     def _compute_detection_costs(self, detections, location_keys, edge_df):
+        # TODO: should verify there's no negatives here
+        # if there are, we should raise that im_shape was probs wrong
         enter_exit_cost = dist_to_edge_cost_func(
             self.im_shape, detections, location_keys
         )

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -277,7 +277,7 @@ def test_to_gurobi_model(human_detections):
 def test_solve_public(human_detections):
     detections, im_shape = human_detections
     tracker = Tracker(im_shape=im_shape, k_neighbours=2)
-    tracked = tracker.solve(detections, "t", ("y", "x"))
+    tracked = tracker.solve(detections, frame_key="t", location_keys=("y", "x"))
     solution_edges = np.asarray(
         [[0, 3], [1, 5], [2, 6], [3, 7], [4, 8], [5, 9], [6, 10]], dtype=int
     )
@@ -295,7 +295,7 @@ def test_solve_debug(human_detections):
     detections, im_shape = human_detections
     tracker = Tracker(im_shape=im_shape, k_neighbours=2)
     tracker.DEBUG_MODE = True
-    tracker.solve(detections, "t", ("y", "x"))
+    tracker.solve(detections, frame_key="t", location_keys=("y", "x"))
 
 
 def test_big_instance_unchanged():

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -54,6 +54,33 @@ def test_build_trees(get_detections):
     np.testing.assert_allclose(detections[detections.t == 0][["y", "x"]], one_dict.data)
 
 
+def test_scale_computed(get_detections):
+    detections = get_detections()
+    tracker = Tracker(im_shape=(20, 40))
+    tracked = tracker.solve(detections, frame_key="t", location_keys=("y", "x"))
+    assert tracker.scale == (1, 1)
+    np.testing.assert_equal(
+        tracked.tracked_detections["y"].values,
+        tracked.tracked_detections["y_scaled"].values,
+    )
+    np.testing.assert_equal(
+        tracked.tracked_detections["x"].values,
+        tracked.tracked_detections["x_scaled"].values,
+    )
+    tracked_scaled = tracker.solve(
+        detections, scale=(2, 2), frame_key="t", location_keys=("y", "x")
+    )
+    assert tracker.scale == (2, 2)
+    np.testing.assert_equal(
+        tracked_scaled.tracked_detections["y_scaled"].values,
+        tracked_scaled.tracked_detections["y"].values * 2,
+    )
+    np.testing.assert_equal(
+        tracked_scaled.tracked_detections["x_scaled"].values,
+        tracked_scaled.tracked_detections["x"].values * 2,
+    )
+
+
 def test_scaled_detections_used_in_solve():
     # detections only move in x coordinate
     detection_dict = {

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -71,6 +71,7 @@ def test_scale_computed(get_detections):
         detections, scale=(2, 2), frame_key="t", location_keys=("y", "x")
     )
     assert tracker.scale == (2, 2)
+    assert tracker.im_shape == (40, 80)
     np.testing.assert_equal(
         tracked_scaled.tracked_detections["y_scaled"].values,
         tracked_scaled.tracked_detections["y"].values * 2,
@@ -100,7 +101,8 @@ def test_scaled_detections_used_in_solve():
     tracked = tracker.solve(
         detections, scale=(0.01, 1), frame_key="t", location_keys=("y", "x")
     )
-
+    # scale correctly changed the image shape
+    assert tracker.im_shape == (0.1, 50)
     # no migration edges will be used
     assert tracked.tracked_edges.empty
     # appearance/exit edges will be used


### PR DESCRIPTION
Previously we were not taking image scale into account when computing costs. This is particularly problematic for 3D datasets where the `z` scale is often different to the `y` and `x` scales i.e. while pixels are usually squares, voxels are not usually cubes.

This PR addresses the issue by maintaining a `*_scaled` column in `detections` for each dimension, and only using this column in cost computations (rather than the original column). The `im_shape` is also scaled accordingly - but it overrides the initial `im_shape` provided.

Added basic tests, but could use more...