### PR TITLE
Refactor center-extracting code to grab `area` as well

### DIFF
--- a/src/tracktour/_io_util.py
+++ b/src/tracktour/_io_util.py
@@ -28,14 +28,12 @@ PROPS_OF_INTEREST = [
     "area",
     "bbox",
     "image",
-    "solidity",
     "slice",
 ]
 # these attributes (PLUS SPATIAL ATTRIBUTES t, [z], y, x and bbox)
 PROPS_OF_EXPORT = [
     "label",
     "area",
-    "solidity",
 ]
 
 

--- a/src/tracktour/_io_util.py
+++ b/src/tracktour/_io_util.py
@@ -174,12 +174,19 @@ def get_centers(segmentation):
             }
         )
         props["t"] = i
-        new_col = props.apply(
-            lambda row: row[centroid_cols]
-            if current_frame[tuple(row[centroid_cols].values.astype(int))]
-            == row["label"]
-            else get_medoid(row),
+
+        def medoid_or_centroid(row):
+            if (
+                current_frame[tuple(row[centroid_cols].values.astype(int))]
+                == row["label"]
+            ):
+                row[centroid_cols] = row[centroid_cols]
+            else:
+                row[centroid_cols] = get_medoid(row)
+            return row
+
+        props = props.apply(
+            medoid_or_centroid,
             axis=1,
         )
-        props[centroid_cols] = new_col
         yield props, centroid_cols


### PR DESCRIPTION
Extract `area` using `regionprops`, use `regionprops_table`. Faster than what we had previously. Also grabs area because we can use that as a very useful feature. 