### PR TITLE
Rewrite track-id assignment

### DIFF
--- a/src/tracktour/_io_util.py
+++ b/src/tracktour/_io_util.py
@@ -4,6 +4,7 @@ import os
 import sys
 import warnings
 
+import networkx as nx
 import numpy as np
 import pandas as pd
 import yaml
@@ -61,8 +62,11 @@ def get_ctc_output(original_seg, tracked_nx, frame_key, value_key, location_keys
     max_id = assign_track_id(mergeless)
     node_df = pd.DataFrame.from_dict(mergeless.nodes, orient="index")
     relabelled_seg = mask_by_id(node_df, original_seg, frame_key, value_key)
+    nx.set_node_attributes(
+        mergeless, nx.get_node_attributes(mergeless, "track-id"), name=value_key
+    )
     track_df = get_ctc_tracks(mergeless)
-    return relabelled_seg, track_df
+    return relabelled_seg, track_df, max_id
 
 
 def get_ctc_ds_name(pth):

--- a/src/tracktour/_viz_util.py
+++ b/src/tracktour/_viz_util.py
@@ -5,8 +5,8 @@ import pandas as pd
 
 def mask_by_id(nodes: pd.DataFrame, seg: np.ndarray, frame_key: str, value_key: str):
     masks = np.zeros_like(seg)
-    max_id = nodes["track-id"].max()
-    for i in range(1, max_id + 1):
+    tids = nodes["track-id"].unique()
+    for i in tids:
         track_nodes = nodes[nodes["track-id"] == i]
         for row in track_nodes.itertuples():
             t = getattr(row, frame_key)
@@ -14,14 +14,9 @@ def mask_by_id(nodes: pd.DataFrame, seg: np.ndarray, frame_key: str, value_key: 
             mask = seg[t] == orig_label
             masks[t][mask] = i
 
-    # colour weird vertices with 1
     unassigned = nodes[nodes["track-id"] == -1]
-    for row in unassigned.itertuples():
-        t = row.t
-        # TODO: breaks for brand new detections that aren't present in the segmentation!
-        orig_label = getattr(row, value_key)
-        mask = seg[t] == orig_label
-        masks[t][mask] = 1
+    if len(unassigned) != 0:
+        raise ValueError("Unassigned track-id for nodes!")
 
     return masks
 

--- a/src/tracktour/cli.py
+++ b/src/tracktour/cli.py
@@ -109,7 +109,7 @@ def ctc(
         k_neighbours=k_neighbours,
     )
     sol_graph = tracked.as_nx_digraph()
-    relabelled_seg, track_df = get_ctc_output(
+    relabelled_seg, track_df, _ = get_ctc_output(
         ims, sol_graph, frame_key, value_key, location_keys
     )
     _save_results(relabelled_seg, track_df, out_directory)


### PR DESCRIPTION
Rewrite track-id assignment to be faster and also more robust. This implementation removes merge involved, division involved and skip edges from the graph and then simply numbers the connected components.