### PR TITLE
Add overlap-based costs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ source = "vcs"
 [tool.hatch.build.targets.wheel]
 only-include = ["src"]
 sources = ["src"]
+packages = ["src"]
 
 # extras
 # https://peps.python.org/pep-0621/#dependencies-optional-dependencies

--- a/src/tracktour/_napari/__init__.py
+++ b/src/tracktour/_napari/__init__.py
@@ -11,10 +11,3 @@ except ModuleNotFoundError as e:
     raise RuntimeError(
         "napari_graph not found. Cannot use plugin functionality without it. Did you install `tracktour[napari]`?"
     ) from e
-
-try:
-    import napari_arboretum
-except ModuleNotFoundError as e:
-    raise RuntimeError(
-        "napari_arboretum not found. Cannot use plugin functionality without it. Did you install `tracktour[napari]`?"
-    ) from e

--- a/src/tracktour/_napari/_merge_explorer.py
+++ b/src/tracktour/_napari/_merge_explorer.py
@@ -20,6 +20,12 @@ class MergeExplorer(Container):
         layout: str = "vertical",
         labels: bool = True,
     ) -> None:
+        try:
+            import napari_arboretum
+        except ModuleNotFoundError as e:
+            raise RuntimeError(
+                "napari_arboretum not found. Cannot use MergeExplorer without it. Did you install `tracktour[napari]`?"
+            ) from e
         super().__init__(
             layout=layout,
             labels=labels,

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -260,7 +260,8 @@ def test_get_all_edges(get_detections):
     enter_exit_cost, div_cost = tracker._compute_detection_costs(
         detections, ("y", "x"), edges
     )
-    detections["enter_exit_cost"] = enter_exit_cost
+    detections["enter_cost"] = enter_exit_cost
+    detections["exit_cost"] = enter_exit_cost
     detections["div_cost"] = div_cost
     all_edges = tracker._get_all_edges(edges, detections, "t")
 
@@ -301,7 +302,8 @@ def test_to_gurobi_model(human_detections):
     enter_exit_cost, div_cost = tracker._compute_detection_costs(
         detections, ("y", "x"), edges
     )
-    detections["enter_exit_cost"] = enter_exit_cost
+    detections["enter_cost"] = enter_exit_cost
+    detections["exit_cost"] = enter_exit_cost
     detections["div_cost"] = div_cost
     m, _, _, _ = tracker._to_gurobi_model(detections, edges, "t", ("y", "x"))
     # assert that we have a flow conserv & demand constraint for each detection


### PR DESCRIPTION
Add option to use overlap-based costs for migration, division and exit. Requires passing a full segmentation array.

- Migration cost is 1 - IOU of destination and source region
- Division cost is 1 - sum(IOU) of all overlapping neighbours
- Appearance is not possible
- Exit is region area divided by the lower quartile region area over the whole segmentation

Right now you can't select individual event costs, we need to change this